### PR TITLE
Circle CI enforce to use Docker Authentication for Docker Hub

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,11 +1,24 @@
+# GLOBAL-ANCHORS - DockerHub Authentication changes applied - PROD-1431 / PROD-1435
+global_dockerhub_login: &global_dockerhub_login
+  run:
+    name: Authenticate with hub.docker.com - DockerHub
+    command: docker login -u $GLOBAL_DOCKERHUB_USERNAME -p $GLOBAL_DOCKERHUB_PASSWORD
+global_remote_docker: &global_remote_docker
+  version: 19.03.13
+global_dockerhub_auth: &global_dockerhub_auth
+  auth:
+    username: $GLOBAL_DOCKERHUB_USERNAME
+    password: $GLOBAL_DOCKERHUB_PASSWORD
 version: 2
 
 jobs:
   build:
     docker:
-      - image: deliveroo/circleci:0.4.1
+      - image: deliveroo/circleci:0.4.2
+        <<: *global_dockerhub_auth
 
     steps:
+      - *global_dockerhub_login
       - checkout
 
       - setup_remote_docker:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,6 +3,9 @@ global_dockerhub_login: &global_dockerhub_login
   run:
     name: Authenticate with hub.docker.com - DockerHub
     command: docker login -u $GLOBAL_DOCKERHUB_USERNAME -p $GLOBAL_DOCKERHUB_PASSWORD
+global_context: &global_context
+  context:
+    - org-global
 global_remote_docker: &global_remote_docker
   version: 19.03.13
 global_dockerhub_auth: &global_dockerhub_auth
@@ -18,10 +21,15 @@ jobs:
         <<: *global_dockerhub_auth
 
     steps:
-      - *global_dockerhub_login
       - checkout
-
       - setup_remote_docker:
           docker_layer_caching: true
-
+          <<: *global_remote_docker
+      - *global_dockerhub_login
       - run: docker build -f build.Dockerfile .
+workflows:
+  version: 2
+  all:
+    jobs:
+      - build:
+          <<: *global_context


### PR DESCRIPTION
PROD-1435: Changes relating to enforcing Docker Hub authentication on CircleCI

- Enforces all actions using Docker Hub to use authentication (not anonymous)
  using CircleCI Global Context - org-global

- Changes Docker setup_remote_docker version to be updated to 19.03.13 due to
  deprecation from CircleCI of older versions

