### PR TITLE
PSC-2805-bump-circleci-to-latest

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ version: 2
 jobs:
   build:
     docker:
-      - image: deliveroo/circleci:0.6.3
+      - image: deliveroo/circleci:4.12.0
 
     steps:
       - checkout


### PR DESCRIPTION

## :writing_hand: Ticket
https://deliveroo.atlassian.net/browse/PSC-2805

## :scroll: What changed and why?
DevSecOps team is switching to Wiz for container scanning. To support this, we've released a new CircleCI tag that integrates the Wiz CLI scan. This PR simply bumps the CircleCI version to the latest version 4.12.0.
