### PR TITLE
feat: ensure branch is checked out and not a file

### DIFF
--- a/src/GitCommandManager.ts
+++ b/src/GitCommandManager.ts
@@ -28,7 +28,7 @@ export class GitCommandManager {
     );
   }
   public checkout(branch: string) {
-    return this.execGit(`git checkout ${branch}`);
+    return this.execGit(`git checkout ${branch} --`);
   }
   public shortStatDiffWithRemote(branch: string) {
     return this.execGit(`git diff ${branch} ${_remoteName}/${branch} --shortstat`, {


### PR DESCRIPTION
Ensure we explicitly checkout the branch, as if the repo has a folder the same name as the branch it can lead to the error `fatal: ambiguous argument 'sandbox': both revision and filename`