### PR TITLE
feat: ensure that git diff also does not fail

### DIFF
--- a/src/GitCommandManager.ts
+++ b/src/GitCommandManager.ts
@@ -31,7 +31,7 @@ export class GitCommandManager {
     return this.execGit(`git checkout ${branch} --`);
   }
   public shortStatDiffWithRemote(branch: string) {
-    return this.execGit(`git diff ${branch} ${_remoteName}/${branch} --shortstat`, {
+    return this.execGit(`git diff ${branch} ${_remoteName}/${branch} --shortstat --`, {
       includeStdOut: true
     });
   }


### PR DESCRIPTION
Ensure we explicitly diff the branch, as if the repo has a folder the same name as the branch it can lead to the error fatal: ambiguous argument 'sandbox': both revision and filename