### PR TITLE
fix: do not remove label if it exists

### DIFF
--- a/src/mergeDeployablePullRequests.ts
+++ b/src/mergeDeployablePullRequests.ts
@@ -76,15 +76,10 @@ const processMergeResults = async (
           const { errorMessage } = rest;
           await github.removeIssueLabel(number, requestDeploymentLabelName);
           await github.createIssueComment(number, createCommentMessage(errorMessage));
-        }
-        if (hasLabel(labels, deployedLabelName)) {
-          await github.removeIssueLabel(number, deployedLabelName);
-        } else if ("message" in rest) {
-          if (!hasLabel(labels, deployedLabelName)) {
-            const { message } = rest;
-            await github.createIssueComment(number, createCommentMessage(message));
-            await github.addIssueLabels(number, deployedLabelName);
-          }
+        } else if ("message" in rest && !hasLabel(labels, deployedLabelName)) {
+          const { message } = rest;
+          await github.createIssueComment(number, createCommentMessage(message));
+          await github.addIssueLabels(number, deployedLabelName);
         }
       }
     )


### PR DESCRIPTION
This action removes the _deployed label_ from a pull request if it already exists, even if the pull request was merged successfully. This causes the deployed label to flap between existing & not existing.

This is problematic because it doesn't accurately represent the status of the PR, and prevents us from using it as a PR check.

This PR fixes this logic.