### PR TITLE
feat: add trigger-workflows input to dispatch CI after merge

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,3 +20,24 @@ Which will add `.github/workflows/merge-pr-to-branch.yml` to your repo, based on
 2. `merge-pr-to-branch` will run and attempt to merge the pull request
     * If successful, the `staged` label will be added along with a comment
     * If unsuccessful, a comment with the error will be added and the `stage` label will be removed
+
+## Triggering a downstream workflow after merge
+
+Pushes made by `GITHUB_TOKEN` do not trigger other workflows
+([GitHub docs](https://docs.github.com/en/actions/using-workflows/triggering-a-workflow#triggering-a-workflow-from-a-workflow)),
+so a CI workflow listening on `push` will not run when this action updates `target-branch`.
+
+Set the optional `trigger-workflow` input to dispatch a workflow against `target-branch` after a
+successful merge:
+
+```yaml
+- uses: deliveroo/merge-pr-to-branch@v8
+  with:
+    target-branch: sandbox
+    request-label-name: sandbox
+    deployed-label-name: sandboxed
+    trigger-workflow: ci-workflows.yml
+```
+
+The named workflow must declare `workflow_dispatch:` under its `on:` triggers. Dispatch only fires
+when the merge actually changes `target-branch` — no-op runs are skipped.

--- a/README.md
+++ b/README.md
@@ -21,14 +21,14 @@ Which will add `.github/workflows/merge-pr-to-branch.yml` to your repo, based on
     * If successful, the `staged` label will be added along with a comment
     * If unsuccessful, a comment with the error will be added and the `stage` label will be removed
 
-## Triggering a downstream workflow after merge
+## Triggering downstream workflows after merge
 
 Pushes made by `GITHUB_TOKEN` do not trigger other workflows
 ([GitHub docs](https://docs.github.com/en/actions/using-workflows/triggering-a-workflow#triggering-a-workflow-from-a-workflow)),
 so a CI workflow listening on `push` will not run when this action updates `target-branch`.
 
-Set the optional `trigger-workflow` input to dispatch a workflow against `target-branch` after a
-successful merge:
+Set the optional `trigger-workflows` input to a newline-separated list of workflow filenames to
+dispatch against `target-branch` after a successful merge:
 
 ```yaml
 - uses: deliveroo/merge-pr-to-branch@v8
@@ -36,8 +36,16 @@ successful merge:
     target-branch: sandbox
     request-label-name: sandbox
     deployed-label-name: sandboxed
-    trigger-workflow: ci-workflows.yml
+    trigger-workflows: |
+      ci-workflows.yml
+      integration-tests.yml
 ```
 
-The named workflow must declare `workflow_dispatch:` under its `on:` triggers. Dispatch only fires
+A single workflow is also fine:
+
+```yaml
+    trigger-workflows: ci-workflows.yml
+```
+
+Each named workflow must declare `workflow_dispatch:` under its `on:` triggers. Dispatch only fires
 when the merge actually changes `target-branch` — no-op runs are skipped.

--- a/__tests__/main.run.test.ts
+++ b/__tests__/main.run.test.ts
@@ -103,6 +103,9 @@ describe("main", () => {
         Array [
           "lock-check-interval-ms",
         ],
+        Array [
+          "trigger-workflow",
+        ],
       ]
     `);
     expect(info.mock.calls).toMatchInlineSnapshot(`
@@ -112,5 +115,78 @@ describe("main", () => {
         ],
       ]
     `);
+  });
+
+  it.each([
+    {
+      name: "dispatches when input set and merge pushed",
+      triggerWorkflow: "ci-workflows.yml",
+      pushed: true,
+      expectDispatchCalls: 1
+    },
+    {
+      name: "skips dispatch when merge did not push",
+      triggerWorkflow: "ci-workflows.yml",
+      pushed: false,
+      expectDispatchCalls: 0
+    },
+    {
+      name: "skips dispatch when input is empty",
+      triggerWorkflow: "",
+      pushed: true,
+      expectDispatchCalls: 0
+    }
+  ])("$name", async ({ triggerWorkflow, pushed, expectDispatchCalls }) => {
+    // arrange
+    const { getInput } = await createMock<typeof import("@actions/core")>("@actions/core");
+    const actions_github = await createMock<typeof import("@actions/github")>("@actions/github");
+    const { GithubApiManager } = await createMock<typeof import("../src/GithubApiManager")>(
+      "../src/GithubApiManager"
+    );
+    const { mergeDeployablePullRequests, getBaseBranch } = await createMock<
+      typeof import("../src/mergeDeployablePullRequests")
+    >("../src/mergeDeployablePullRequests");
+    await createMock<typeof import("../src/GitCommandManager")>("../src/GitCommandManager");
+    const { acquireLock } = await createMock<typeof import("../src/acquireLock")>(
+      "../src/acquireLock"
+    );
+
+    const inputValues = new Map([
+      ["target-branch", "target-branch-value"],
+      ["lock-branch-name", "lock-branch-name-value"],
+      ["lock-check-interval-ms", "1"],
+      ["repo-token", "repo-token-value"],
+      ["request-label-name", "request-label"],
+      ["deployed-label-name", "deployed-label"],
+      ["trigger-workflow", triggerWorkflow]
+    ]);
+    getInput.mockImplementation(key => inputValues.get(key) || "");
+    const mockContext = {
+      payload: {
+        repository: { owner: { login: "owner_login" }, name: "repo_name" }
+      }
+    } as any;
+    Object.defineProperty(actions_github, "context", { get: () => mockContext });
+    getBaseBranch.mockReturnValue("base_branch");
+    jest.spyOn(fs.promises, "mkdtemp").mockResolvedValue("temp_dir");
+    process.env.GITHUB_ACTOR = "github_actor";
+    acquireLock.mockResolvedValue(true);
+    mergeDeployablePullRequests.mockResolvedValue(pushed);
+
+    // act
+    const { run } = await import("../src/main.run");
+    await run();
+
+    // assert
+    const githubInstance = GithubApiManager.mock.instances[0] as jest.Mocked<
+      import("../src/GithubApiManager").GithubApiManager
+    >;
+    expect(githubInstance.dispatchWorkflow).toHaveBeenCalledTimes(expectDispatchCalls);
+    if (expectDispatchCalls > 0) {
+      expect(githubInstance.dispatchWorkflow).toHaveBeenCalledWith(
+        triggerWorkflow,
+        "target-branch-value"
+      );
+    }
   });
 });

--- a/__tests__/main.run.test.ts
+++ b/__tests__/main.run.test.ts
@@ -104,7 +104,7 @@ describe("main", () => {
           "lock-check-interval-ms",
         ],
         Array [
-          "trigger-workflow",
+          "trigger-workflows",
         ],
       ]
     `);
@@ -119,24 +119,36 @@ describe("main", () => {
 
   it.each([
     {
-      name: "dispatches when input set and merge pushed",
-      triggerWorkflow: "ci-workflows.yml",
+      name: "dispatches single workflow when input set and merge pushed",
+      triggerWorkflowsInput: "ci-workflows.yml",
       pushed: true,
-      expectDispatchCalls: 1
+      expectedDispatched: ["ci-workflows.yml"]
+    },
+    {
+      name: "dispatches each workflow on a newline-separated list",
+      triggerWorkflowsInput: "ci-workflows.yml\nintegration.yml\n  e2e.yml  ",
+      pushed: true,
+      expectedDispatched: ["ci-workflows.yml", "integration.yml", "e2e.yml"]
     },
     {
       name: "skips dispatch when merge did not push",
-      triggerWorkflow: "ci-workflows.yml",
+      triggerWorkflowsInput: "ci-workflows.yml",
       pushed: false,
-      expectDispatchCalls: 0
+      expectedDispatched: []
     },
     {
       name: "skips dispatch when input is empty",
-      triggerWorkflow: "",
+      triggerWorkflowsInput: "",
       pushed: true,
-      expectDispatchCalls: 0
+      expectedDispatched: []
+    },
+    {
+      name: "skips dispatch when input is whitespace-only",
+      triggerWorkflowsInput: "  \n\n  ",
+      pushed: true,
+      expectedDispatched: []
     }
-  ])("$name", async ({ triggerWorkflow, pushed, expectDispatchCalls }) => {
+  ])("$name", async ({ triggerWorkflowsInput, pushed, expectedDispatched }) => {
     // arrange
     const { getInput } = await createMock<typeof import("@actions/core")>("@actions/core");
     const actions_github = await createMock<typeof import("@actions/github")>("@actions/github");
@@ -158,7 +170,7 @@ describe("main", () => {
       ["repo-token", "repo-token-value"],
       ["request-label-name", "request-label"],
       ["deployed-label-name", "deployed-label"],
-      ["trigger-workflow", triggerWorkflow]
+      ["trigger-workflows", triggerWorkflowsInput]
     ]);
     getInput.mockImplementation(key => inputValues.get(key) || "");
     const mockContext = {
@@ -181,12 +193,9 @@ describe("main", () => {
     const githubInstance = GithubApiManager.mock.instances[0] as jest.Mocked<
       import("../src/GithubApiManager").GithubApiManager
     >;
-    expect(githubInstance.dispatchWorkflow).toHaveBeenCalledTimes(expectDispatchCalls);
-    if (expectDispatchCalls > 0) {
-      expect(githubInstance.dispatchWorkflow).toHaveBeenCalledWith(
-        triggerWorkflow,
-        "target-branch-value"
-      );
-    }
+    expect(githubInstance.dispatchWorkflow).toHaveBeenCalledTimes(expectedDispatched.length);
+    expectedDispatched.forEach(workflow => {
+      expect(githubInstance.dispatchWorkflow).toHaveBeenCalledWith(workflow, "target-branch-value");
+    });
   });
 });

--- a/action.yml
+++ b/action.yml
@@ -20,8 +20,8 @@ inputs:
   deployed-label-name:
     description: 'Label which indicates a PR was successfully merged to target-branch'
     default: staged
-  trigger-workflow:
-    description: 'Optional workflow filename (e.g. ci-workflows.yml) to dispatch against target-branch after a successful merge. Workaround for GitHub not firing workflows from pushes made with GITHUB_TOKEN.'
+  trigger-workflows:
+    description: 'Optional newline-separated list of workflow filenames (e.g. ci-workflows.yml) to dispatch against target-branch after a successful merge. Workaround for GitHub not firing workflows from pushes made with GITHUB_TOKEN.'
     default: ''
 runs:
   using: 'docker'

--- a/action.yml
+++ b/action.yml
@@ -20,6 +20,9 @@ inputs:
   deployed-label-name:
     description: 'Label which indicates a PR was successfully merged to target-branch'
     default: staged
+  trigger-workflow:
+    description: 'Optional workflow filename (e.g. ci-workflows.yml) to dispatch against target-branch after a successful merge. Workaround for GitHub not firing workflows from pushes made with GITHUB_TOKEN.'
+    default: ''
 runs:
   using: 'docker'
   image: 'Dockerfile'

--- a/src/GithubApiManager.ts
+++ b/src/GithubApiManager.ts
@@ -54,4 +54,11 @@ export class GithubApiManager {
   public createIssueComment(issue_number: number, body: string) {
     return this.client.issues.createComment({ ...this.options, issue_number, body });
   }
+  public dispatchWorkflow(workflow_id: string, ref: string) {
+    return this.client.actions.createWorkflowDispatch({
+      ...this.options,
+      workflow_id,
+      ref
+    });
+  }
 }

--- a/src/GithubApiManager.ts
+++ b/src/GithubApiManager.ts
@@ -55,10 +55,13 @@ export class GithubApiManager {
     return this.client.issues.createComment({ ...this.options, issue_number, body });
   }
   public dispatchWorkflow(workflow_id: string, ref: string) {
-    return this.client.actions.createWorkflowDispatch({
-      ...this.options,
-      workflow_id,
-      ref
-    });
+    return this.client.request(
+      "POST /repos/:owner/:repo/actions/workflows/:workflow_id/dispatches",
+      {
+        ...this.options,
+        workflow_id,
+        ref
+      }
+    );
   }
 }

--- a/src/main.run.ts
+++ b/src/main.run.ts
@@ -14,7 +14,7 @@ const lockBranchNameInputName = "lock-branch-name";
 const lockCheckIntervalInputName = "lock-check-interval-ms";
 const requestLabelNameInputName = "request-label-name";
 const deployedLabelNameInputName = "deployed-label-name";
-const triggerWorkflowInputName = "trigger-workflow";
+const triggerWorkflowsInputName = "trigger-workflows";
 
 export async function run() {
   try {
@@ -61,10 +61,15 @@ export async function run() {
       requestLabelName,
       deployedLabelName
     );
-    const triggerWorkflow = getInput(triggerWorkflowInputName);
-    if (pushed && triggerWorkflow) {
-      info(`Dispatching workflow '${triggerWorkflow}' against '${targetBranch}'.`);
-      await github.dispatchWorkflow(triggerWorkflow, targetBranch);
+    const triggerWorkflows = getInput(triggerWorkflowsInputName)
+      .split("\n")
+      .map(s => s.trim())
+      .filter(s => s.length > 0);
+    if (pushed && triggerWorkflows.length > 0) {
+      for (const workflow of triggerWorkflows) {
+        info(`Dispatching workflow '${workflow}' against '${targetBranch}'.`);
+        await github.dispatchWorkflow(workflow, targetBranch);
+      }
     }
     await removeLock(github, lockBranchName);
   } catch (error) {

--- a/src/main.run.ts
+++ b/src/main.run.ts
@@ -14,6 +14,7 @@ const lockBranchNameInputName = "lock-branch-name";
 const lockCheckIntervalInputName = "lock-check-interval-ms";
 const requestLabelNameInputName = "request-label-name";
 const deployedLabelNameInputName = "deployed-label-name";
+const triggerWorkflowInputName = "trigger-workflow";
 
 export async function run() {
   try {
@@ -52,7 +53,7 @@ export async function run() {
     await retry(acquireThisLock, 5, "Could not acquire lock", lockCheckIntervalInMs);
     const workingDirectory = await mkdtemp("git-workspace");
     const git = new GitCommandManager(workingDirectory, user, token);
-    await mergeDeployablePullRequests(
+    const pushed = await mergeDeployablePullRequests(
       github,
       git,
       targetBranch,
@@ -60,6 +61,11 @@ export async function run() {
       requestLabelName,
       deployedLabelName
     );
+    const triggerWorkflow = getInput(triggerWorkflowInputName);
+    if (pushed && triggerWorkflow) {
+      info(`Dispatching workflow '${triggerWorkflow}' against '${targetBranch}'.`);
+      await github.dispatchWorkflow(triggerWorkflow, targetBranch);
+    }
     await removeLock(github, lockBranchName);
   } catch (error) {
     setFailed(JSON.stringify(serializeError(error)));

--- a/src/mergeDeployablePullRequests.ts
+++ b/src/mergeDeployablePullRequests.ts
@@ -47,7 +47,7 @@ export const mergeDeployablePullRequests = async (
   if (diffResults.stdOutLines.length === 0) {
     info(`No difference between local and remote. Skipping push.`);
     git.resetHardToRemote(targetBranch);
-    return;
+    return false;
   }
   info(
     `Pushing local branch as differences found between local and remote:\n${diffResults.stdOutLines.join(
@@ -56,6 +56,7 @@ export const mergeDeployablePullRequests = async (
   );
   await git.forcePush();
   await processMergeResults(mergeResults, github, requestDeploymentLabelName, deployedLabelName);
+  return true;
 };
 
 const processMergeResults = async (


### PR DESCRIPTION
## Summary

- Adds optional `trigger-workflows` input. Newline-separated list of workflow filenames; dispatches each against `target-branch` after a successful merge.
- Skips dispatch on no-op runs (no diff to push) and when the input is empty — opt-in, no behaviour change for existing consumers.
- Documents the use case in README; new `main.run` test cases cover single, multi, no-push, empty, and whitespace-only inputs.

## Motivation

Pushes made with the default `GITHUB_TOKEN` [do not trigger downstream workflows](https://docs.github.com/en/actions/using-workflows/triggering-a-workflow#triggering-a-workflow-from-a-workflow). So a CI workflow listening on `push` against `target-branch` (e.g. `sandbox`) never runs when this action updates the branch. Today every consumer hits this — `deliveroo/ecs-cap-provider-strategiser` and `deliveroo/traffic-gateway` both work around it with extra steps (third-party action / inline `curl`). Folding it into this action removes the duplication and supports multiple downstream workflows in one place.

## Usage

```yaml
- uses: deliveroo/merge-pr-to-branch@v8
  with:
    target-branch: sandbox
    request-label-name: sandbox
    deployed-label-name: sandboxed
    trigger-workflows: |
      ci-workflows.yml
      integration-tests.yml
```

A single value also works (`trigger-workflows: ci-workflows.yml`).

## Test plan

- [ ] CI: jest test suite passes.
- [ ] CI: `tsc` build succeeds.
- [x] End-to-end smoke test from a consumer repo (`deliveroo/ecs-cap-provider-strategiser`) — confirmed dispatch fires and `ci-workflows` runs on `sandbox` after a labelled merge.
- [ ] After merge: cut `v8` rolling tag at the new HEAD so consumers can adopt. Existing `@v7` consumers are unaffected.
- [ ] Follow-up PR on `deliveroo/ecs-cap-provider-strategiser` (deliveroo/ecs-cap-provider-strategiser#204) will switch to `trigger-workflows: ci-workflows.yml` once `v8` is available.

🤖 Generated with [Claude Code](https://claude.com/claude-code)